### PR TITLE
Add a config struct for patching gspPresentBuffer

### DIFF
--- a/src/pkrd/game/oras/hook.rs
+++ b/src/pkrd/game/oras/hook.rs
@@ -1,7 +1,7 @@
 use super::{frame, reader};
 use crate::pkrd::{
     display,
-    hook::{HookableProcess, HookedProcess, SupportedTitle},
+    hook::{HookableProcess, HookedProcess, PatchPresentFramebufferConfig, SupportedTitle},
     reader::Reader,
 };
 use alloc::boxed::Box;
@@ -28,14 +28,12 @@ impl HookableProcess for PokemonORAS {
     }
 
     fn install_hook(process: &DebugProcess, pkrd_handle: Handle) -> CtrResult<()> {
-        Self::patch_present_framebuffer(
-            process,
-            pkrd_handle,
-            0x8000000,
-            0x6000000,
-            0x148758,
-            0x5d0000,
-            0x164ee0,
-        )
+        let config = PatchPresentFramebufferConfig {
+            is_extended_memory: false,
+            get_screen_addr: 0x164ee0,
+            present_framebuffer_addr: 0x148758,
+            hook_vars_addr: 0x5d0000,
+        };
+        Self::patch_present_framebuffer(process, pkrd_handle, config)
     }
 }

--- a/src/pkrd/game/sm/hook.rs
+++ b/src/pkrd/game/sm/hook.rs
@@ -1,7 +1,7 @@
 use super::{frame, reader};
 use crate::pkrd::{
     display,
-    hook::{HookableProcess, HookedProcess, SupportedTitle},
+    hook::{HookableProcess, HookedProcess, PatchPresentFramebufferConfig, SupportedTitle},
     reader::Reader,
 };
 use alloc::boxed::Box;
@@ -28,14 +28,12 @@ impl HookableProcess for PokemonSM {
     }
 
     fn install_hook(process: &DebugProcess, pkrd_handle: Handle) -> CtrResult<()> {
-        Self::patch_present_framebuffer(
-            process,
-            pkrd_handle,
-            0x30000000,
-            0x34a8d84,
-            0x278540,
-            0x600000,
-            0x2794c4,
-        )
+        let config = PatchPresentFramebufferConfig {
+            is_extended_memory: true,
+            get_screen_addr: 0x2794c4,
+            present_framebuffer_addr: 0x278540,
+            hook_vars_addr: 0x600000,
+        };
+        Self::patch_present_framebuffer(process, pkrd_handle, config)
     }
 }

--- a/src/pkrd/game/usum/hook.rs
+++ b/src/pkrd/game/usum/hook.rs
@@ -1,7 +1,7 @@
 use super::{frame, reader};
 use crate::pkrd::{
     display,
-    hook::{HookableProcess, HookedProcess, SupportedTitle},
+    hook::{HookableProcess, HookedProcess, PatchPresentFramebufferConfig, SupportedTitle},
     reader::Reader,
 };
 use alloc::boxed::Box;
@@ -28,14 +28,12 @@ impl HookableProcess for PokemonUSUM {
     }
 
     fn install_hook(process: &DebugProcess, pkrd_handle: Handle) -> CtrResult<()> {
-        Self::patch_present_framebuffer(
-            process,
-            pkrd_handle,
-            0x30000000,
-            0x34a8d84,
-            0x279bb4,
-            0x630000,
-            0x27ab38,
-        )
+        let config = PatchPresentFramebufferConfig {
+            is_extended_memory: true,
+            get_screen_addr: 0x27ab38,
+            present_framebuffer_addr: 0x279bb4,
+            hook_vars_addr: 0x630000,
+        };
+        Self::patch_present_framebuffer(process, pkrd_handle, config)
     }
 }

--- a/src/pkrd/game/xy/hook.rs
+++ b/src/pkrd/game/xy/hook.rs
@@ -1,7 +1,7 @@
 use super::{frame, reader};
 use crate::pkrd::{
     display,
-    hook::{HookableProcess, HookedProcess, SupportedTitle},
+    hook::{HookableProcess, HookedProcess, PatchPresentFramebufferConfig, SupportedTitle},
     reader::Reader,
 };
 use alloc::boxed::Box;
@@ -28,14 +28,12 @@ impl HookableProcess for PokemonXY {
     }
 
     fn install_hook(process: &DebugProcess, pkrd_handle: Handle) -> CtrResult<()> {
-        Self::patch_present_framebuffer(
-            process,
-            pkrd_handle,
-            0x8000000,
-            0x6000000,
-            0x149354,
-            0x5c0000,
-            0x1646b4,
-        )
+        let config = PatchPresentFramebufferConfig {
+            is_extended_memory: false,
+            get_screen_addr: 0x1646b4,
+            present_framebuffer_addr: 0x149354,
+            hook_vars_addr: 0x5c0000,
+        };
+        Self::patch_present_framebuffer(process, pkrd_handle, config)
     }
 }

--- a/src/pkrd/hook/hookable_process/config.rs
+++ b/src/pkrd/hook/hookable_process/config.rs
@@ -1,0 +1,33 @@
+/// Configuration used to patch a game's `gspPresentBuffer` function.
+pub struct PatchPresentFramebufferConfig {
+    /// Determines if a game uses extended memory mode.
+    /// usum and sm will be true.  All other games should be false.
+    pub is_extended_memory: bool,
+    /// `gspPresentBuffer` in libctru.
+    /// This can be found by searching for the byte sequence: `9a 8f 07 ee`, which is `mcr p15,0x0,r8,cr7,cr10,0x4`.
+    /// You may need to modify the search to account for registers other than r8, but r8 is usually used.
+    pub present_framebuffer_addr: u32,
+    /// The address of the first function called in `gspPresentBuffer`.
+    pub get_screen_addr: u32,
+    /// Most games will probably require this to be aligned with 0x10000,
+    /// but that's not necessarilly true for all games.
+    pub hook_vars_addr: u32,
+}
+
+impl PatchPresentFramebufferConfig {
+    pub fn get_heap_addr(&self) -> u32 {
+        if self.is_extended_memory {
+            0x30000000
+        } else {
+            0x8000000
+        }
+    }
+
+    pub fn get_heap_size(&self) -> u32 {
+        if self.is_extended_memory {
+            0x34a8d84
+        } else {
+            0x6000000
+        }
+    }
+}

--- a/src/pkrd/hook/hookable_process/mod.rs
+++ b/src/pkrd/hook/hookable_process/mod.rs
@@ -1,0 +1,5 @@
+mod config;
+pub use config::*;
+
+mod process;
+pub use process::*;


### PR DESCRIPTION
This PR adds a config struct for patching gspPresentBuffer in the hopes of:
- Naming fields so it's easier to read at a glance
- Pulling shared configs (heaps/sizes) into a common place
- Adding some documentation to the configuration

This PR also adds a check to make sure the hook variable address is valid.