### PR TITLE
Gen 6 initial seed patch

### DIFF
--- a/src/pkrd/game/oras/hook.rs
+++ b/src/pkrd/game/oras/hook.rs
@@ -38,6 +38,9 @@ impl HookableProcess for PokemonORAS {
             present_framebuffer_addr: 0x148758,
             hook_vars_addr: 0x5d0000,
         };
-        Self::patch_present_framebuffer(process, pkrd_handle, config)
+        let inital_seed_address = 0x12e5c8;
+
+        Self::patch_present_framebuffer(process, pkrd_handle, config);
+        Self::patch_inital_seed(process, inital_seed_address)
     }
 }

--- a/src/pkrd/game/oras/reader.rs
+++ b/src/pkrd/game/oras/reader.rs
@@ -17,6 +17,7 @@ impl<'a> Reader for PokemonORASReader<'a> {
 }
 
 impl<'a> Gen6Reader for PokemonORASReader<'a> {
+    const INITIAL_SEED_OFFSET: usize = 0xc59e40;
     const MT_STATE_INDEX_OFFSET: usize = 0xc59e44;
     const PARTY_OFFSET: usize = 0xCFB26C;
     const EGG_READY_OFFSET: usize = 0xC88358;

--- a/src/pkrd/game/xy/hook.rs
+++ b/src/pkrd/game/xy/hook.rs
@@ -38,6 +38,9 @@ impl HookableProcess for PokemonXY {
             present_framebuffer_addr: 0x149354,
             hook_vars_addr: 0x5c0000,
         };
-        Self::patch_present_framebuffer(process, pkrd_handle, config)
+        let inital_seed_address = 0x1254f8;
+
+        Self::patch_present_framebuffer(process, pkrd_handle, config);
+        Self::patch_inital_seed(process, inital_seed_address)
     }
 }

--- a/src/pkrd/game/xy/reader.rs
+++ b/src/pkrd/game/xy/reader.rs
@@ -17,6 +17,7 @@ impl<'a> Reader for PokemonXYReader<'a> {
 }
 
 impl<'a> Gen6Reader for PokemonXYReader<'a> {
+    const INITIAL_SEED_OFFSET: usize = 0xc52844;
     const MT_STATE_INDEX_OFFSET: usize = 0xc52848;
     const PARTY_OFFSET: usize = 0xCE1CF8;
     const EGG_READY_OFFSET: usize = 0xC80124;

--- a/src/pkrd/hook/hookable_process/process.rs
+++ b/src/pkrd/hook/hookable_process/process.rs
@@ -96,6 +96,16 @@ pub trait HookableProcess: HookedProcess {
 
         Ok(())
     }
+
+    fn patch_inital_seed(process: &DebugProcess, address: u32) -> CtrResult<()> {
+        let patch_code: [u32; 1] = [0xe5001004];
+
+        process
+            .write_bytes(address, safe_transmute::transmute_to_bytes(&patch_code))
+            .unwrap();
+
+        Ok(())
+    }
 }
 
 /// A process that is hooked.

--- a/src/pkrd/reader/gen6.rs
+++ b/src/pkrd/reader/gen6.rs
@@ -2,12 +2,17 @@ use super::{pkm, Reader};
 use ctr::res::CtrResult;
 
 pub trait Gen6Reader: Reader {
+    const INITIAL_SEED_OFFSET: usize;
     const MT_STATE_INDEX_OFFSET: usize;
     const PARTY_OFFSET: usize;
     const EGG_READY_OFFSET: usize;
     const EGG_OFFSET: usize;
     const PARENT1_OFFSET: usize;
     const PARENT2_OFFSET: usize;
+
+    fn get_initial_seed(&self) -> CtrResult<usize> {
+        self.read(Self::INITIAL_SEED_OFFSET)
+    }
 
     fn get_mt_state_index(&self) -> CtrResult<usize> {
         self.read(Self::MT_STATE_INDEX_OFFSET)

--- a/src/pkrd/views/rng6.rs
+++ b/src/pkrd/views/rng6.rs
@@ -12,11 +12,16 @@ pub fn run_view(
         let black = display::Color::black();
         let white = display::Color::white();
 
-        screen.paint_square(&black, x, y, 200, 32)?;
+        screen.paint_square(&black, x, y, 200, 48)?;
 
         x += 10;
         y += 4;
         screen.draw_string(&white, "Hello from rust!", x, y)?;
+
+        y += 16;
+        let init_seed = game.get_initial_seed()?;
+        let seed_text = &alloc::format!("Init seed: {:08x}", init_seed);
+        screen.draw_string(&white, seed_text, x, y)?;
 
         y += 16;
         let mt_state_index = game.get_mt_state_index()?;


### PR DESCRIPTION
Allow ORAS and XY to access the initial seed. Unlike SM and USUM, the
initial seed does not get saved anywhere permanently in memory.

This patch overwrites a nop instruction to store the initial seed 4
bytes before the MT index memory address.