### PR TITLE
Add Gen 7 Wild Views

### DIFF
--- a/src/pkrd/game/sm/reader.rs
+++ b/src/pkrd/game/sm/reader.rs
@@ -26,9 +26,9 @@ impl Gen7Reader for PokemonSMReader {
     const SOS_OFFSET: usize = 0x002F7B8;
     const SOS_SEED_OFFSET: usize = 0x0038C44;
     const SOS_CHAIN_LENGTH: usize = 0x003960D;
-    const PELAGO_OFFSET_1: usize = 0x33110EF2;
-    const PELAGO_OFFSET_2: usize = 0x33110FDE;
-    const PELAGO_OFFSET_3: usize = 0x331110CA;
+    const PELAGO_OFFSET_1: usize = 0x3110EF2;
+    const PELAGO_OFFSET_2: usize = 0x3110FDE;
+    const PELAGO_OFFSET_3: usize = 0x31110CA;
     const EGG_READY_OFFSET: usize = 0x313EDD8;
     const EGG_OFFSET: usize = 0x313EDDC;
     const PARENT1_OFFSET: usize = 0x313EC01;

--- a/src/pkrd/game/sm/reader.rs
+++ b/src/pkrd/game/sm/reader.rs
@@ -26,9 +26,9 @@ impl Gen7Reader for PokemonSMReader {
     const SOS_OFFSET: usize = 0x002F7B8;
     const SOS_SEED_OFFSET: usize = 0x0038C44;
     const SOS_CHAIN_LENGTH: usize = 0x003960D;
-    const PELAGO_OFFSET_1: usize = 0x002F7B8;
-    const PELAGO_OFFSET_2: usize = 0x002F7B8;
-    const PELAGO_OFFSET_3: usize = 0x002F7B8;
+    const PELAGO_OFFSET_1: usize = 0x33110EF2;
+    const PELAGO_OFFSET_2: usize = 0x33110FDE;
+    const PELAGO_OFFSET_3: usize = 0x331110CA;
     const EGG_READY_OFFSET: usize = 0x313EDD8;
     const EGG_OFFSET: usize = 0x313EDDC;
     const PARENT1_OFFSET: usize = 0x313EC01;

--- a/src/pkrd/game/sm/reader.rs
+++ b/src/pkrd/game/sm/reader.rs
@@ -26,6 +26,9 @@ impl Gen7Reader for PokemonSMReader {
     const SOS_OFFSET: usize = 0x002F7B8;
     const SOS_SEED_OFFSET: usize = 0x0038C44;
     const SOS_CHAIN_LENGTH: usize = 0x003960D;
+    const PELAGO_OFFSET_1: usize = 0x002F7B8;
+    const PELAGO_OFFSET_2: usize = 0x002F7B8;
+    const PELAGO_OFFSET_3: usize = 0x002F7B8;
     const EGG_READY_OFFSET: usize = 0x313EDD8;
     const EGG_OFFSET: usize = 0x313EDDC;
     const PARENT1_OFFSET: usize = 0x313EC01;
@@ -33,4 +36,9 @@ impl Gen7Reader for PokemonSMReader {
     const IS_PARENT1_OCCUPIED_OFFSET: usize = 0x313EC00;
     const IS_PARENT2_OCCUPIED_OFFSET: usize = 0x313ECE9;
     const SHINY_CHARM_OFFSET: usize = 0x30d5930;
+    const WILD_TITLE: &'static str = "Wild";
+    const SOS_TITLE: &'static str = "SOS";
+    const PELAGO_TITLE_1: &'static str = "Pelago Slot 1";
+    const PELAGO_TITLE_2: &'static str = "Pelago Slot 2";
+    const PELAGO_TITLE_3: &'static str = "Pelago Slot 3";
 }

--- a/src/pkrd/game/usum/reader.rs
+++ b/src/pkrd/game/usum/reader.rs
@@ -26,6 +26,9 @@ impl Gen7Reader for PokemonUSUMReader {
     const SOS_OFFSET: usize = 0x002F9A0;
     const SOS_SEED_OFFSET: usize = 0x0038E30;
     const SOS_CHAIN_LENGTH: usize = 0x00397F9;
+    const PELAGO_OFFSET_1: usize = 0x002F7B8;
+    const PELAGO_OFFSET_2: usize = 0x002F7B8;
+    const PELAGO_OFFSET_3: usize = 0x002F7B8;
     const EGG_READY_OFFSET: usize = 0x307B1E8;
     const EGG_OFFSET: usize = 0x307B1EC;
     const PARENT1_OFFSET: usize = 0x307B011;
@@ -33,4 +36,9 @@ impl Gen7Reader for PokemonUSUMReader {
     const IS_PARENT1_OCCUPIED_OFFSET: usize = 0x307B010;
     const IS_PARENT2_OCCUPIED_OFFSET: usize = 0x307B0F9;
     const SHINY_CHARM_OFFSET: usize = 0x3012008;
+    const WILD_TITLE: &'static str = "Wild";
+    const SOS_TITLE: &'static str = "SOS";
+    const PELAGO_TITLE_1: &'static str = "Pelago Slot 1";
+    const PELAGO_TITLE_2: &'static str = "Pelago Slot 2";
+    const PELAGO_TITLE_3: &'static str = "Pelago Slot 3";
 }

--- a/src/pkrd/game/usum/reader.rs
+++ b/src/pkrd/game/usum/reader.rs
@@ -26,9 +26,9 @@ impl Gen7Reader for PokemonUSUMReader {
     const SOS_OFFSET: usize = 0x002F9A0;
     const SOS_SEED_OFFSET: usize = 0x0038E30;
     const SOS_CHAIN_LENGTH: usize = 0x00397F9;
-    const PELAGO_OFFSET_1: usize = 0x3304D342;
-    const PELAGO_OFFSET_2: usize = 0x3304D256;
-    const PELAGO_OFFSET_3: usize = 0x3304D342;
+    const PELAGO_OFFSET_1: usize = 0x304D342;
+    const PELAGO_OFFSET_2: usize = 0x304D256;
+    const PELAGO_OFFSET_3: usize = 0x304D16A;
     const EGG_READY_OFFSET: usize = 0x307B1E8;
     const EGG_OFFSET: usize = 0x307B1EC;
     const PARENT1_OFFSET: usize = 0x307B011;

--- a/src/pkrd/game/usum/reader.rs
+++ b/src/pkrd/game/usum/reader.rs
@@ -26,9 +26,9 @@ impl Gen7Reader for PokemonUSUMReader {
     const SOS_OFFSET: usize = 0x002F9A0;
     const SOS_SEED_OFFSET: usize = 0x0038E30;
     const SOS_CHAIN_LENGTH: usize = 0x00397F9;
-    const PELAGO_OFFSET_1: usize = 0x002F7B8;
-    const PELAGO_OFFSET_2: usize = 0x002F7B8;
-    const PELAGO_OFFSET_3: usize = 0x002F7B8;
+    const PELAGO_OFFSET_1: usize = 0x3304D342;
+    const PELAGO_OFFSET_2: usize = 0x3304D256;
+    const PELAGO_OFFSET_3: usize = 0x3304D342;
     const EGG_READY_OFFSET: usize = 0x307B1E8;
     const EGG_OFFSET: usize = 0x307B1EC;
     const PARENT1_OFFSET: usize = 0x307B011;

--- a/src/pkrd/reader/gen7.rs
+++ b/src/pkrd/reader/gen7.rs
@@ -84,6 +84,14 @@ pub trait Gen7Reader: Reader {
         self.default_read(Self::EGG_OFFSET)
     }
 
+    fn get_sos_seed(&self) -> u32 {
+        self.default_read(Self::SOS_SEED_OFFSET)
+    }
+
+    fn get_sos_chain(&self) -> u8 {
+        self.default_read(Self::SOS_CHAIN_LENGTH)
+    }
+
     fn get_party_pkm(&self, slot: PartySlot) -> pkm::Pk7 {
         let offset = ((slot.value() as usize) * 484) + Self::PARTY_OFFSET;
         self.default_read::<pkm::Pk7Data>(offset).into()

--- a/src/pkrd/reader/gen7.rs
+++ b/src/pkrd/reader/gen7.rs
@@ -1,6 +1,14 @@
 use crate::utils::party_slot::PartySlot;
+use crate::utils::CircularCounter;
 use no_std_io::Reader;
 use pkm_rs::pkm;
+
+pub struct Wild {
+    pub title: &'static str,
+    pub pkx: pkm::Pk7,
+}
+
+pub type WildSlot = CircularCounter<0, 4>;
 
 #[cfg_attr(not(target_os = "horizon"), mocktopus::macros::mockable)]
 pub trait Gen7Reader: Reader {
@@ -14,11 +22,50 @@ pub trait Gen7Reader: Reader {
     const SOS_CHAIN_LENGTH: usize;
     const EGG_READY_OFFSET: usize;
     const EGG_OFFSET: usize;
+    const PELAGO_OFFSET_1: usize;
+    const PELAGO_OFFSET_2: usize;
+    const PELAGO_OFFSET_3: usize;
     const PARENT1_OFFSET: usize;
     const PARENT2_OFFSET: usize;
     const IS_PARENT1_OCCUPIED_OFFSET: usize;
     const IS_PARENT2_OCCUPIED_OFFSET: usize;
     const SHINY_CHARM_OFFSET: usize;
+    const WILD_TITLE: &'static str;
+    const SOS_TITLE: &'static str;
+    const PELAGO_TITLE_1: &'static str;
+    const PELAGO_TITLE_2: &'static str;
+    const PELAGO_TITLE_3: &'static str;
+
+    fn get_wild(&self, wild_slot: WildSlot) -> Wild {
+        match wild_slot.value() {
+            1 => Wild {
+                title: Self::SOS_TITLE,
+                pkx: self.default_read::<pkm::Pk7Data>(Self::SOS_OFFSET).into(),
+            },
+            2 => Wild {
+                title: Self::PELAGO_TITLE_1,
+                pkx: self
+                    .default_read::<pkm::Pk7Data>(Self::PELAGO_OFFSET_1)
+                    .into(),
+            },
+            3 => Wild {
+                title: Self::PELAGO_TITLE_2,
+                pkx: self
+                    .default_read::<pkm::Pk7Data>(Self::PELAGO_OFFSET_2)
+                    .into(),
+            },
+            4 => Wild {
+                title: Self::PELAGO_TITLE_3,
+                pkx: self
+                    .default_read::<pkm::Pk7Data>(Self::PELAGO_OFFSET_3)
+                    .into(),
+            },
+            _ => Wild {
+                title: Self::WILD_TITLE,
+                pkx: self.default_read::<pkm::Pk7Data>(Self::WILD_OFFSET).into(),
+            },
+        }
+    }
 
     fn get_initial_seed(&self) -> u32 {
         self.default_read(Self::INITIAL_SEED_OFFSET)

--- a/src/pkrd/rng/gen7.rs
+++ b/src/pkrd/rng/gen7.rs
@@ -86,6 +86,9 @@ mod test {
         const SOS_OFFSET: usize = 0;
         const SOS_SEED_OFFSET: usize = 0;
         const SOS_CHAIN_LENGTH: usize = 0;
+        const PELAGO_OFFSET_1: usize = 0;
+        const PELAGO_OFFSET_2: usize = 0;
+        const PELAGO_OFFSET_3: usize = 0;
         const EGG_READY_OFFSET: usize = 0;
         const EGG_OFFSET: usize = 0;
         const PARENT1_OFFSET: usize = 0;
@@ -93,6 +96,11 @@ mod test {
         const IS_PARENT1_OCCUPIED_OFFSET: usize = 0;
         const IS_PARENT2_OCCUPIED_OFFSET: usize = 0;
         const SHINY_CHARM_OFFSET: usize = 0;
+        const WILD_TITLE: &'static str = "Wild";
+        const SOS_TITLE: &'static str = "SOS";
+        const PELAGO_TITLE_1: &'static str = "Pelago Slot 1";
+        const PELAGO_TITLE_2: &'static str = "Pelago Slot 2";
+        const PELAGO_TITLE_3: &'static str = "Pelago Slot 3";
     }
 
     mod update_sfmt {

--- a/src/pkrd/views/gen7/handler.rs
+++ b/src/pkrd/views/gen7/handler.rs
@@ -1,4 +1,5 @@
 use super::{daycare, rng as rng_view};
+use crate::pkrd::reader::WildSlot;
 use crate::{
     pkrd::{display, reader, rng, views::pkm},
     utils::party_slot::PartySlot,
@@ -23,6 +24,7 @@ pub struct Gen7Views {
     left_view: LeftGen7View,
     right_view: RightGen7View,
     party_slot: PartySlot,
+    wild_slot: WildSlot,
 }
 
 impl Default for Gen7Views {
@@ -31,6 +33,7 @@ impl Default for Gen7Views {
             left_view: LeftGen7View::None,
             right_view: RightGen7View::None,
             party_slot: PartySlot::default(),
+            wild_slot: WildSlot::default(),
         }
     }
 }
@@ -56,6 +59,10 @@ impl Gen7Views {
         if self.left_view == LeftGen7View::PartyView {
             self.party_slot = pkm::party::input::next_party_slot(self.party_slot);
         }
+
+        if self.left_view == LeftGen7View::WildView {
+            self.wild_slot = pkm::wild::input::next_wild_slot(self.wild_slot);
+        }
     }
 
     pub fn run_views<GameReader: reader::Gen7Reader>(
@@ -73,8 +80,8 @@ impl Gen7Views {
                 pkm::party::draw(screen, &pkx, self.party_slot)?;
             }
             LeftGen7View::WildView => {
-                let pkx = game.get_wild_pkm();
-                pkm::wild::draw(screen, &pkx)?
+                let wild = game.get_wild(self.wild_slot);
+                pkm::wild::draw(screen, wild)?
             }
             LeftGen7View::None => {}
         }

--- a/src/pkrd/views/gen7/handler.rs
+++ b/src/pkrd/views/gen7/handler.rs
@@ -7,22 +7,22 @@ use crate::{
 use ctr::res::CtrResult;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum LeftGen7View {
+enum TopLeftGen7View {
     None,
     PartyView,
     WildView,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum RightGen7View {
+enum TopRightGen7View {
     None,
     RngView,
     DaycareView,
 }
 
 pub struct Gen7Views {
-    left_view: LeftGen7View,
-    right_view: RightGen7View,
+    left_view: TopLeftGen7View,
+    right_view: TopRightGen7View,
     party_slot: PartySlot,
     wild_slot: WildSlot,
 }
@@ -30,8 +30,8 @@ pub struct Gen7Views {
 impl Default for Gen7Views {
     fn default() -> Self {
         Self {
-            left_view: LeftGen7View::None,
-            right_view: RightGen7View::None,
+            left_view: TopLeftGen7View::None,
+            right_view: TopRightGen7View::None,
             party_slot: PartySlot::default(),
             wild_slot: WildSlot::default(),
         }
@@ -41,26 +41,26 @@ impl Default for Gen7Views {
 impl Gen7Views {
     fn update_views(&mut self) {
         self.right_view = match self.right_view {
-            RightGen7View::RngView if rng_view::input::toggle() => RightGen7View::None,
-            RightGen7View::DaycareView if daycare::input::toggle() => RightGen7View::None,
-            _ if rng_view::input::toggle() => RightGen7View::RngView,
-            _ if daycare::input::toggle() => RightGen7View::DaycareView,
+            TopRightGen7View::RngView if rng_view::input::toggle() => TopRightGen7View::None,
+            TopRightGen7View::DaycareView if daycare::input::toggle() => TopRightGen7View::None,
+            _ if rng_view::input::toggle() => TopRightGen7View::RngView,
+            _ if daycare::input::toggle() => TopRightGen7View::DaycareView,
             view => view,
         };
 
         self.left_view = match self.left_view {
-            LeftGen7View::WildView if pkm::wild::input::toggle() => LeftGen7View::None,
-            LeftGen7View::PartyView if pkm::party::input::toggle() => LeftGen7View::None,
-            _ if pkm::wild::input::toggle() => LeftGen7View::WildView,
-            _ if pkm::party::input::toggle() => LeftGen7View::PartyView,
+            TopLeftGen7View::WildView if pkm::wild::input::toggle() => TopLeftGen7View::None,
+            TopLeftGen7View::PartyView if pkm::party::input::toggle() => TopLeftGen7View::None,
+            _ if pkm::wild::input::toggle() => TopLeftGen7View::WildView,
+            _ if pkm::party::input::toggle() => TopLeftGen7View::PartyView,
             view => view,
         };
 
-        if self.left_view == LeftGen7View::PartyView {
+        if self.left_view == TopLeftGen7View::PartyView {
             self.party_slot = pkm::party::input::next_party_slot(self.party_slot);
         }
 
-        if self.left_view == LeftGen7View::WildView {
+        if self.left_view == TopLeftGen7View::WildView {
             self.wild_slot = pkm::wild::input::next_wild_slot(self.wild_slot);
         }
     }
@@ -75,21 +75,21 @@ impl Gen7Views {
         self.update_views();
 
         match self.left_view {
-            LeftGen7View::PartyView => {
+            TopLeftGen7View::PartyView => {
                 let pkx = game.get_party_pkm(self.party_slot);
                 pkm::party::draw(screen, &pkx, self.party_slot)?;
             }
-            LeftGen7View::WildView => {
+            TopLeftGen7View::WildView => {
                 let wild = game.get_wild(self.wild_slot);
                 pkm::wild::draw(screen, wild)?
             }
-            LeftGen7View::None => {}
+            TopLeftGen7View::None => {}
         }
 
         match self.right_view {
-            RightGen7View::RngView => rng_view::draw(screen, game, rng)?,
-            RightGen7View::DaycareView => daycare::draw(screen, game)?,
-            RightGen7View::None => {}
+            TopRightGen7View::RngView => rng_view::draw(screen, game, rng)?,
+            TopRightGen7View::DaycareView => daycare::draw(screen, game)?,
+            TopRightGen7View::None => {}
         }
 
         Ok(())

--- a/src/pkrd/views/gen7/rng.rs
+++ b/src/pkrd/views/gen7/rng.rs
@@ -20,6 +20,8 @@ pub fn draw(
         let sfmt_state_bytes = sfmt_state.to_ne_bytes();
         let sfmt_state_parts: [u32; 2] = safe_transmute::transmute_one_pedantic(&sfmt_state_bytes)?;
         let sfmt_advances = rng.get_sfmt_advances();
+        let sos_seed = game.get_sos_seed();
+        let sos_chain = game.get_sos_chain();
 
         view::draw_right(
             screen,
@@ -29,6 +31,8 @@ pub fn draw(
                 &alloc::format!("Curr state[1]: {:08X}", sfmt_state_parts[1]),
                 &alloc::format!("Curr state[0]: {:08X}", sfmt_state_parts[0]),
                 &alloc::format!("Advances: {}", sfmt_advances),
+                &alloc::format!("SOS Seed: {:08X}", sos_seed),
+                &alloc::format!("SOS Chain Length: {}", sos_chain),
             ],
         )?;
     }

--- a/src/pkrd/views/pkm/wild.rs
+++ b/src/pkrd/views/pkm/wild.rs
@@ -1,15 +1,36 @@
-use crate::pkrd::display;
+use crate::pkrd::{display, reader::Wild};
 use ctr::res::CtrResult;
-use pkm_rs::pkm;
 
 pub mod input {
     use ctr::hid::{Button, Global, InterfaceDevice};
 
+    use crate::pkrd::reader::WildSlot;
+
     pub fn toggle() -> bool {
         Global::is_just_pressed(Button::Start | Button::Dleft)
     }
+
+    fn increment() -> bool {
+        Global::is_just_pressed(Button::Select | Button::Dright)
+    }
+
+    fn decrement() -> bool {
+        Global::is_just_pressed(Button::Select | Button::Dleft)
+    }
+
+    pub fn next_wild_slot(mut slot: WildSlot) -> WildSlot {
+        if increment() {
+            slot.increment();
+        }
+
+        if decrement() {
+            slot.decrement();
+        }
+
+        slot
+    }
 }
 
-pub fn draw(screen: &mut display::DirectWriteScreen, pkx: &impl pkm::Pkx) -> CtrResult<()> {
-    super::pkx::draw(screen, "Wild", pkx)
+pub fn draw(screen: &mut display::DirectWriteScreen, wild: Wild) -> CtrResult<()> {
+    super::pkx::draw(screen, wild.title, &wild.pkx)
 }


### PR DESCRIPTION
This adds Pelago and SOS views within the Wild View for SM/USUM. Also, SOS seed and chain length are added to the Main RNG View.

~~Pelago offsets still need to be tested for accuracy, especially Slot 3.~~ Tested, and confirmed working!
SOS only shows the first Pokemon, second still has work to be done before it can added.