### PR TITLE
Edit Gen 7 Main RNG View

### DIFF
--- a/src/pkrd/display/screen.rs
+++ b/src/pkrd/display/screen.rs
@@ -55,6 +55,10 @@ pub trait Screen {
         self.get_context().is_top_screen
     }
 
+    fn get_is_bottom_screen(&self) -> bool {
+        self.get_is_top_screen() == false
+    }
+
     /// # Safety
     /// The caller needs to make sure:
     /// - The x is never above 320 for a bottom screen

--- a/src/pkrd/reader/gen7.rs
+++ b/src/pkrd/reader/gen7.rs
@@ -10,6 +10,8 @@ pub struct Wild {
 
 pub type WildSlot = CircularCounter<0, 4>;
 
+pub type RngSlot = CircularCounter<0, 1>;
+
 #[cfg_attr(not(target_os = "horizon"), mocktopus::macros::mockable)]
 pub trait Gen7Reader: Reader {
     const INITIAL_SEED_OFFSET: usize;

--- a/src/pkrd/views/gen6/daycare.rs
+++ b/src/pkrd/views/gen6/daycare.rs
@@ -1,5 +1,5 @@
 use crate::pkrd::reader::{Daycare, DaycareSlot};
-use crate::pkrd::{display, display::Screen, views::view};
+use crate::pkrd::{display, views::view};
 use crate::utils::daycare;
 use ctr::res::CtrResult;
 
@@ -33,27 +33,25 @@ pub mod input {
 }
 
 pub fn draw(screen: &mut display::DirectWriteScreen, daycare: &Daycare) -> CtrResult<()> {
-    if screen.get_is_top_screen() {
-        let parent1 = &daycare.parent_1;
-        let parent2 = &daycare.parent_2;
-        let is_masuda_method = daycare::is_daycare_masuda_method(parent1, parent2);
+    let parent1 = &daycare.parent_1;
+    let parent2 = &daycare.parent_2;
+    let is_masuda_method = daycare::is_daycare_masuda_method(parent1, parent2);
 
-        view::draw_top_right(
-            screen,
-            daycare.daycare_title,
-            &[
-                &alloc::format!("Egg Ready: {}", daycare.is_egg_ready),
-                &daycare::format_egg_parent(1, parent1),
-                &daycare::format_egg_parent(2, parent2),
-                "",
-                &alloc::format!("Egg[1]: {:08X}", daycare.egg_seed[0]),
-                &alloc::format!("Egg[0]: {:08X}", daycare.egg_seed[1]),
-                "",
-                &alloc::format!("Masuda Method: {}", is_masuda_method),
-                daycare.daycare_footer,
-            ],
-        )?;
-    }
+    view::draw_top_right(
+        screen,
+        daycare.daycare_title,
+        &[
+            &alloc::format!("Egg Ready: {}", daycare.is_egg_ready),
+            &daycare::format_egg_parent(1, parent1),
+            &daycare::format_egg_parent(2, parent2),
+            "",
+            &alloc::format!("Egg[1]: {:08X}", daycare.egg_seed[0]),
+            &alloc::format!("Egg[0]: {:08X}", daycare.egg_seed[1]),
+            "",
+            &alloc::format!("Masuda Method: {}", is_masuda_method),
+            daycare.daycare_footer,
+        ],
+    )?;
 
     Ok(())
 }

--- a/src/pkrd/views/gen6/help.rs
+++ b/src/pkrd/views/gen6/help.rs
@@ -1,4 +1,4 @@
-use crate::pkrd::display::{DirectWriteScreen, Screen};
+use crate::pkrd::display::DirectWriteScreen;
 use crate::pkrd::views::view;
 use ctr::res::CtrResult;
 
@@ -11,24 +11,21 @@ pub mod input {
 }
 
 pub fn draw(screen: &mut DirectWriteScreen) -> CtrResult<()> {
-    if !screen.get_is_top_screen() {
-        view::draw_bottom(
-            screen,
-            "PokeReader Gen 6 Help Menu",
-            &[
-                "",
-                "X+Up: Show this menu",
-                "Start+Up: Main RNG View",
-                "Start+Down: Daycare View",
-                "Start+Right: Party View",
-                "Select+Left: Decrement current view",
-                "Select+Right: Increment current view",
-                "Start+Select: Pause game",
-                "Pause+A: Unpause game",
-                "Pause+Start: Unpause game",
-                "Pause+Select: Advance one frame",
-            ],
-        )?;
-    }
-    Ok(())
+    view::draw_bottom(
+        screen,
+        "PokeReader Gen 6 Help Menu",
+        &[
+            "",
+            "X+Up: Show this menu",
+            "Start+Up: Main RNG View",
+            "Start+Down: Daycare View",
+            "Start+Right: Party View",
+            "Select+Left: Decrement current view",
+            "Select+Right: Increment current view",
+            "Start+Select: Pause game",
+            "Pause+A: Unpause game",
+            "Pause+Start: Unpause game",
+            "Pause+Select: Advance one frame",
+        ],
+    )
 }

--- a/src/pkrd/views/gen6/rng.rs
+++ b/src/pkrd/views/gen6/rng.rs
@@ -1,4 +1,4 @@
-use crate::pkrd::{display, display::Screen, reader, rng, views::view};
+use crate::pkrd::{display, reader, rng, views::view};
 use ctr::res::CtrResult;
 
 pub mod input {
@@ -14,29 +14,27 @@ pub fn draw(
     game: &impl reader::Gen6Reader,
     rng: &rng::Gen6Rng,
 ) -> CtrResult<()> {
-    if screen.get_is_top_screen() {
-        let init_seed = game.get_initial_seed();
-        let mt_state = game.get_mt_state();
-        let mt_advances = rng.get_mt_advances();
-        let tinymt_advances = rng.get_tinymt_advances();
-        let initial_state = rng.get_initial_tinymt_state();
-        let current_state = game.get_tinymt_state();
+    let init_seed = game.get_initial_seed();
+    let mt_state = game.get_mt_state();
+    let mt_advances = rng.get_mt_advances();
+    let tinymt_advances = rng.get_tinymt_advances();
+    let initial_state = rng.get_initial_tinymt_state();
+    let current_state = game.get_tinymt_state();
 
-        view::draw_top_right(
-            screen,
-            "Main RNG View",
-            &[
-                &alloc::format!("Init seed: {:08X}", init_seed),
-                &alloc::format!("Curr state: {:08X}", mt_state),
-                &alloc::format!("MT Advances: {}", mt_advances),
-                &alloc::format!("TinyMT Advances: {}", tinymt_advances),
-                &alloc::format!("[3]{:08X} [2]{:08X}", initial_state[3], initial_state[2]),
-                &alloc::format!("[1]{:08X} [0]{:08X}", initial_state[1], initial_state[0]),
-                &alloc::format!("[3]{:08X} [2]{:08X}", current_state[3], current_state[2]),
-                &alloc::format!("[1]{:08X} [0]{:08X}", current_state[1], current_state[0]),
-            ],
-        )?;
-    }
+    view::draw_top_right(
+        screen,
+        "Main RNG View",
+        &[
+            &alloc::format!("Init seed: {:08X}", init_seed),
+            &alloc::format!("Curr state: {:08X}", mt_state),
+            &alloc::format!("MT Advances: {}", mt_advances),
+            &alloc::format!("TinyMT Advances: {}", tinymt_advances),
+            &alloc::format!("[3]{:08X} [2]{:08X}", initial_state[3], initial_state[2]),
+            &alloc::format!("[1]{:08X} [0]{:08X}", initial_state[1], initial_state[0]),
+            &alloc::format!("[3]{:08X} [2]{:08X}", current_state[3], current_state[2]),
+            &alloc::format!("[1]{:08X} [0]{:08X}", current_state[1], current_state[0]),
+        ],
+    )?;
 
     Ok(())
 }

--- a/src/pkrd/views/gen7/daycare.rs
+++ b/src/pkrd/views/gen7/daycare.rs
@@ -1,4 +1,4 @@
-use crate::pkrd::{display, display::Screen, reader, views::view};
+use crate::pkrd::{display, reader, views::view};
 use crate::utils::daycare;
 use ctr::res::CtrResult;
 
@@ -14,32 +14,30 @@ pub fn draw(
     screen: &mut display::DirectWriteScreen,
     game: &impl reader::Gen7Reader,
 ) -> CtrResult<()> {
-    if screen.get_is_top_screen() {
-        let is_egg_ready = game.get_is_egg_ready();
-        let parent1 = game.get_egg_parent_1();
-        let parent2 = game.get_egg_parent_2();
-        let egg_seed = game.get_egg_seed();
-        let has_shiny_charm = game.get_has_shiny_charm();
-        let is_masuda_method = daycare::is_daycare_masuda_method(&parent1, &parent2);
+    let is_egg_ready = game.get_is_egg_ready();
+    let parent1 = game.get_egg_parent_1();
+    let parent2 = game.get_egg_parent_2();
+    let egg_seed = game.get_egg_seed();
+    let has_shiny_charm = game.get_has_shiny_charm();
+    let is_masuda_method = daycare::is_daycare_masuda_method(&parent1, &parent2);
 
-        view::draw_top_right(
-            screen,
-            "Daycare View",
-            &[
-                &alloc::format!("Egg Ready: {}", is_egg_ready),
-                &daycare::format_egg_parent(1, &parent1),
-                &daycare::format_egg_parent(2, &parent2),
-                "",
-                &alloc::format!("Egg[0]: {:08X}", egg_seed[3]),
-                &alloc::format!("Egg[1]: {:08X}", egg_seed[2]),
-                &alloc::format!("Egg[2]: {:08X}", egg_seed[1]),
-                &alloc::format!("Egg[3]: {:08X}", egg_seed[0]),
-                "",
-                &alloc::format!("Shiny Charm: {}", has_shiny_charm),
-                &alloc::format!("Masuda Method: {}", is_masuda_method),
-            ],
-        )?;
-    }
+    view::draw_top_right(
+        screen,
+        "Daycare View",
+        &[
+            &alloc::format!("Egg Ready: {}", is_egg_ready),
+            &daycare::format_egg_parent(1, &parent1),
+            &daycare::format_egg_parent(2, &parent2),
+            "",
+            &alloc::format!("Egg[0]: {:08X}", egg_seed[3]),
+            &alloc::format!("Egg[1]: {:08X}", egg_seed[2]),
+            &alloc::format!("Egg[2]: {:08X}", egg_seed[1]),
+            &alloc::format!("Egg[3]: {:08X}", egg_seed[0]),
+            "",
+            &alloc::format!("Shiny Charm: {}", has_shiny_charm),
+            &alloc::format!("Masuda Method: {}", is_masuda_method),
+        ],
+    )?;
 
     Ok(())
 }

--- a/src/pkrd/views/gen7/handler.rs
+++ b/src/pkrd/views/gen7/handler.rs
@@ -1,5 +1,5 @@
 use super::{daycare, help as help_view, rng as rng_view};
-use crate::pkrd::reader::WildSlot;
+use crate::pkrd::reader::{RngSlot, WildSlot};
 use crate::{
     pkrd::{display, reader, rng, views::pkm},
     utils::party_slot::PartySlot,
@@ -32,6 +32,7 @@ pub struct Gen7Views {
     entire_view: BottomGen7View,
     party_slot: PartySlot,
     wild_slot: WildSlot,
+    rng_slot: RngSlot,
 }
 
 impl Default for Gen7Views {
@@ -42,6 +43,7 @@ impl Default for Gen7Views {
             entire_view: BottomGen7View::None,
             party_slot: PartySlot::default(),
             wild_slot: WildSlot::default(),
+            rng_slot: RngSlot::default(),
         }
     }
 }
@@ -70,6 +72,10 @@ impl Gen7Views {
 
         if self.left_view == TopLeftGen7View::WildView {
             self.wild_slot = pkm::wild::input::next_wild_slot(self.wild_slot);
+        }
+
+        if self.left_view == TopRightGen7View::RngView {
+            self.rng_slot = rng_view::input::next_rng_slot(self.rng_slot);
         }
 
         self.entire_view = match self.entire_view {
@@ -101,7 +107,7 @@ impl Gen7Views {
         }
 
         match self.right_view {
-            TopRightGen7View::RngView => rng_view::draw(screen, game, rng)?,
+            TopRightGen7View::RngView => rng_view::draw(screen, game, rng, self.rng_slot)?,
             TopRightGen7View::DaycareView => daycare::draw(screen, game)?,
             TopRightGen7View::None => {}
         }

--- a/src/pkrd/views/gen7/handler.rs
+++ b/src/pkrd/views/gen7/handler.rs
@@ -74,7 +74,7 @@ impl Gen7Views {
             self.wild_slot = pkm::wild::input::next_wild_slot(self.wild_slot);
         }
 
-        if self.left_view == TopRightGen7View::RngView {
+        if self.right_view == TopRightGen7View::RngView {
             self.rng_slot = rng_view::input::next_rng_slot(self.rng_slot);
         }
 

--- a/src/pkrd/views/gen7/help.rs
+++ b/src/pkrd/views/gen7/help.rs
@@ -1,4 +1,4 @@
-use crate::pkrd::display::{DirectWriteScreen, Screen};
+use crate::pkrd::display::DirectWriteScreen;
 use crate::pkrd::views::view;
 use ctr::res::CtrResult;
 
@@ -11,25 +11,22 @@ pub mod input {
 }
 
 pub fn draw(screen: &mut DirectWriteScreen) -> CtrResult<()> {
-    if !screen.get_is_top_screen() {
-        view::draw_bottom(
-            screen,
-            "PokeReader Gen 7 Help Menu",
-            &[
-                "",
-                "X+Up: Show this menu",
-                "Start+Up: Main RNG View",
-                "Start+Down: Daycare View",
-                "Start+Left: Wild View",
-                "Start+Right: Party View",
-                "Select+Left: Decrement current view",
-                "Select+Right: Increment current view",
-                "Start+Select: Pause game",
-                "Pause+A: Unpause game",
-                "Pause+Start: Unpause game",
-                "Pause+Select: Advance one frame",
-            ],
-        )?;
-    }
-    Ok(())
+    view::draw_bottom(
+        screen,
+        "PokeReader Gen 7 Help Menu",
+        &[
+            "",
+            "X+Up: Show this menu",
+            "Start+Up: Main RNG View",
+            "Start+Down: Daycare View",
+            "Start+Left: Wild View",
+            "Start+Right: Party View",
+            "Select+Left: Decrement current view",
+            "Select+Right: Increment current view",
+            "Start+Select: Pause game",
+            "Pause+A: Unpause game",
+            "Pause+Start: Unpause game",
+            "Pause+Select: Advance one frame",
+        ],
+    )
 }

--- a/src/pkrd/views/gen7/rng.rs
+++ b/src/pkrd/views/gen7/rng.rs
@@ -1,5 +1,5 @@
 use crate::pkrd::reader::RngSlot;
-use crate::pkrd::{display, display::Screen, reader, rng, views::view};
+use crate::pkrd::{display, reader, rng, views::view};
 use ctr::{res::CtrResult, safe_transmute};
 
 pub mod input {
@@ -37,12 +37,10 @@ pub fn draw(
     rng: &rng::Gen7Rng,
     rng_slot: RngSlot,
 ) -> CtrResult<()> {
-    if screen.get_is_top_screen() {
-        if rng_slot.value() == 0 {
-            draw_main(screen, game, rng)?;
-        } else {
-            draw_sos(screen, game)?;
-        }
+    if rng_slot.value() == 0 {
+        draw_main(screen, game, rng)?;
+    } else {
+        draw_sos(screen, game)?;
     }
 
     Ok(())

--- a/src/pkrd/views/gen7/rng.rs
+++ b/src/pkrd/views/gen7/rng.rs
@@ -3,6 +3,7 @@ use crate::pkrd::{display, display::Screen, reader, rng, views::view};
 use ctr::{res::CtrResult, safe_transmute};
 
 pub mod input {
+    use super::*;
     use ctr::hid::{Button, Global, InterfaceDevice};
 
     pub fn toggle() -> bool {
@@ -37,36 +38,52 @@ pub fn draw(
     rng_slot: RngSlot,
 ) -> CtrResult<()> {
     if screen.get_is_top_screen() {
-        let init_seed = game.get_initial_seed();
-        let sfmt_state = game.get_sfmt_state();
-        let sfmt_state_bytes = sfmt_state.to_ne_bytes();
-        let sfmt_state_parts: [u32; 2] = safe_transmute::transmute_one_pedantic(&sfmt_state_bytes)?;
-        let sfmt_advances = rng.get_sfmt_advances();
-        let sos_seed = game.get_sos_seed();
-        let sos_chain = game.get_sos_chain();
-
         if rng_slot.value() == 0 {
-            view::draw_top_right(
-                screen,
-                "Main RNG View",
-                &[
-                    &alloc::format!("Init seed: {:08X}", init_seed),
-                    &alloc::format!("Curr state[1]: {:08X}", sfmt_state_parts[1]),
-                    &alloc::format!("Curr state[0]: {:08X}", sfmt_state_parts[0]),
-                    &alloc::format!("Advances: {}", sfmt_advances),
-                ],
-            )?;
+            draw_main(screen, game, rng)?;
         } else {
-            view::draw_top_right(
-                screen,
-                "SOS RNG View",
-                &[
-                    &alloc::format!("SOS Seed: {:08X}", sos_seed),
-                    &alloc::format!("SOS Chain Length: {}", sos_chain),
-                ],
-            )?;
+            draw_sos(screen, game)?;
         }
     }
 
     Ok(())
+}
+
+pub fn draw_main(
+    screen: &mut display::DirectWriteScreen,
+    game: &impl reader::Gen7Reader,
+    rng: &rng::Gen7Rng,
+) -> CtrResult<()> {
+    let init_seed = game.get_initial_seed();
+    let sfmt_state = game.get_sfmt_state();
+    let sfmt_state_bytes = sfmt_state.to_ne_bytes();
+    let sfmt_state_parts: [u32; 2] = safe_transmute::transmute_one_pedantic(&sfmt_state_bytes)?;
+    let sfmt_advances = rng.get_sfmt_advances();
+
+    view::draw_top_right(
+        screen,
+        "Main RNG View",
+        &[
+            &alloc::format!("Init seed: {:08X}", init_seed),
+            &alloc::format!("Curr state[1]: {:08X}", sfmt_state_parts[1]),
+            &alloc::format!("Curr state[0]: {:08X}", sfmt_state_parts[0]),
+            &alloc::format!("Advances: {}", sfmt_advances),
+        ],
+    )
+}
+
+pub fn draw_sos(
+    screen: &mut display::DirectWriteScreen,
+    game: &impl reader::Gen7Reader,
+) -> CtrResult<()> {
+    let sos_seed = game.get_sos_seed();
+    let sos_chain = game.get_sos_chain();
+
+    view::draw_top_right(
+        screen,
+        "SOS RNG View",
+        &[
+            &alloc::format!("SOS Seed: {:08X}", sos_seed),
+            &alloc::format!("SOS Chain Length: {}", sos_chain),
+        ],
+    )
 }

--- a/src/pkrd/views/pkm/pkx.rs
+++ b/src/pkrd/views/pkm/pkx.rs
@@ -1,5 +1,5 @@
 use crate::{
-    pkrd::{display, display::Screen, views::view},
+    pkrd::{display, views::view},
     utils,
 };
 use alloc::string::ToString;
@@ -11,28 +11,26 @@ pub fn draw(
     title: &str,
     pkx: &impl pkm::Pkx,
 ) -> CtrResult<()> {
-    if screen.get_is_top_screen() {
-        let species = pkx.species().to_string();
-        let ability = pkx.ability().to_string();
+    let species = pkx.species().to_string();
+    let ability = pkx.ability().to_string();
 
-        view::draw_top_left(
-            screen,
-            title,
-            &[
-                &alloc::format!("Species: {}", utils::string::ellipse(&species, 13)),
-                &alloc::format!("PID: {:08X}", pkx.pid()),
-                &alloc::format!("PSV: {:04}", pkx.psv()),
-                &alloc::format!("Nature: {}", pkx.nature()),
-                &alloc::format!(
-                    "Ability: {} ({})",
-                    utils::string::ellipse(&ability, 9),
-                    pkx.ability_number()
-                ),
-                &alloc::format!("IVs: {}", pkx.ivs()),
-                &alloc::format!("HPower: {}", pkx.hidden_power()),
-            ],
-        )?;
-    }
+    view::draw_top_left(
+        screen,
+        title,
+        &[
+            &alloc::format!("Species: {}", utils::string::ellipse(&species, 13)),
+            &alloc::format!("PID: {:08X}", pkx.pid()),
+            &alloc::format!("PSV: {:04}", pkx.psv()),
+            &alloc::format!("Nature: {}", pkx.nature()),
+            &alloc::format!(
+                "Ability: {} ({})",
+                utils::string::ellipse(&ability, 9),
+                pkx.ability_number()
+            ),
+            &alloc::format!("IVs: {}", pkx.ivs()),
+            &alloc::format!("HPower: {}", pkx.hidden_power()),
+        ],
+    )?;
 
     Ok(())
 }

--- a/src/pkrd/views/view.rs
+++ b/src/pkrd/views/view.rs
@@ -58,5 +58,9 @@ pub fn draw_bottom(
     title: &str,
     content: &[&str],
 ) -> CtrResult<()> {
-    draw(screen, title, content, 308, 6, 10)
+    if screen.get_is_bottom_screen() {
+        draw(screen, title, content, 308, 6, 10)?;
+    }
+
+    Ok(())
 }

--- a/src/pkrd/views/view.rs
+++ b/src/pkrd/views/view.rs
@@ -34,7 +34,11 @@ pub fn draw_top_left(
     title: &str,
     content: &[&str],
 ) -> CtrResult<()> {
-    draw(screen, title, content, 184, 6, 10)
+    if screen.get_is_top_screen() {
+        draw(screen, title, content, 184, 6, 10)?;
+    }
+
+    Ok(())
 }
 
 pub fn draw_top_right(
@@ -42,7 +46,11 @@ pub fn draw_top_right(
     title: &str,
     content: &[&str],
 ) -> CtrResult<()> {
-    draw(screen, title, content, 192, 200, 10)
+    if screen.get_is_top_screen() {
+        draw(screen, title, content, 192, 200, 10)?;
+    }
+
+    Ok(())
 }
 
 pub fn draw_bottom(


### PR DESCRIPTION
The main rng view for Gen 7 has been split into Main RNG View and SOS RNG View, and they can be swapped between by using `Select + Left/Right`.