### PR TITLE
Add Gen7TID and TSV

### DIFF
--- a/src/pkrd/game/sm/reader.rs
+++ b/src/pkrd/game/sm/reader.rs
@@ -41,4 +41,5 @@ impl Gen7Reader for PokemonSMReader {
     const PELAGO_TITLE_1: &'static str = "Pelago Slot 1";
     const PELAGO_TITLE_2: &'static str = "Pelago Slot 2";
     const PELAGO_TITLE_3: &'static str = "Pelago Slot 3";
+    const ID_OFFSET: usize = 0x30D67D0;
 }

--- a/src/pkrd/game/usum/reader.rs
+++ b/src/pkrd/game/usum/reader.rs
@@ -41,4 +41,5 @@ impl Gen7Reader for PokemonUSUMReader {
     const PELAGO_TITLE_1: &'static str = "Pelago Slot 1";
     const PELAGO_TITLE_2: &'static str = "Pelago Slot 2";
     const PELAGO_TITLE_3: &'static str = "Pelago Slot 3";
+    const ID_OFFSET: usize = 0x3012818;
 }

--- a/src/pkrd/reader/gen7.rs
+++ b/src/pkrd/reader/gen7.rs
@@ -42,11 +42,9 @@ pub trait Gen7Reader: Reader {
         sidtid % 1000000
     }
 
-    fn get_tsv(&self) -> u32 {
-        let sidtid = self.default_read::<u32>(Self::ID_OFFSET);
-
-        let tid = sidtid & 0xFFFF;
-        let sid = sidtid >> 0x10;
+    fn get_tsv(&self) -> u16 {
+        let sid = self.default_read::<u16>(Self::ID_OFFSET);
+        let tid = self.default_read::<u16>(Self::ID_OFFSET + 2);
 
         (tid ^ sid) >> 4
     }

--- a/src/pkrd/reader/gen7.rs
+++ b/src/pkrd/reader/gen7.rs
@@ -34,6 +34,22 @@ pub trait Gen7Reader: Reader {
     const PELAGO_TITLE_1: &'static str;
     const PELAGO_TITLE_2: &'static str;
     const PELAGO_TITLE_3: &'static str;
+    const ID_OFFSET: usize;
+
+    fn get_tid(&self) -> u32 {
+        let sidtid = self.default_read::<u32>(Self::ID_OFFSET);
+
+        sidtid % 1000000
+    }
+
+    fn get_tsv(&self) -> u32 {
+        let sidtid = self.default_read::<u32>(Self::ID_OFFSET);
+
+        let tid = sidtid & 0xFFFF;
+        let sid = sidtid >> 0x10;
+
+        (tid ^ sid) >> 4
+    }
 
     fn get_wild(&self, wild_slot: WildSlot) -> WildPokemon<pkm::Pk7> {
         match wild_slot.value() {

--- a/src/pkrd/rng/gen7.rs
+++ b/src/pkrd/rng/gen7.rs
@@ -101,6 +101,7 @@ mod test {
         const PELAGO_TITLE_1: &'static str = "Pelago Slot 1";
         const PELAGO_TITLE_2: &'static str = "Pelago Slot 2";
         const PELAGO_TITLE_3: &'static str = "Pelago Slot 3";
+        const ID_OFFSET: usize = 0;
     }
 
     mod update_sfmt {

--- a/src/pkrd/views/gen7/rng.rs
+++ b/src/pkrd/views/gen7/rng.rs
@@ -56,6 +56,8 @@ pub fn draw_main(
     let sfmt_state_bytes = sfmt_state.to_ne_bytes();
     let sfmt_state_parts: [u32; 2] = safe_transmute::transmute_one_pedantic(&sfmt_state_bytes)?;
     let sfmt_advances = rng.get_sfmt_advances();
+    let tid = game.get_tid();
+    let tsv = game.get_tsv();
 
     view::draw_top_right(
         screen,
@@ -65,6 +67,9 @@ pub fn draw_main(
             &alloc::format!("Curr state[1]: {:08X}", sfmt_state_parts[1]),
             &alloc::format!("Curr state[0]: {:08X}", sfmt_state_parts[0]),
             &alloc::format!("Advances: {}", sfmt_advances),
+            &alloc::format!(""),
+            &alloc::format!("Gen7TID: {}", tid),
+            &alloc::format!("TSV: {}", tsv),
         ],
     )
 }


### PR DESCRIPTION
Now the main rng view shows the player's Gen7TID, and TSV for rng purposes.