### PR TITLE
Fix backwards display for ORAS eggs

### DIFF
--- a/src/gen6/reader.rs
+++ b/src/gen6/reader.rs
@@ -117,8 +117,8 @@ impl Gen6Reader {
     pub fn daycare1(&self) -> Daycare {
         Daycare {
             egg_seed: [
-                pnp::read(self.addrs.egg_seed_1),
                 pnp::read(self.addrs.egg_seed_1 + 0x4),
+                pnp::read(self.addrs.egg_seed_1),
             ],
             is_egg_ready: pnp::read::<u8>(self.addrs.egg_ready_1) != 0,
             parent1: self.egg_parent(self.addrs.is_parent1_occupied_1, self.addrs.parent1_1),
@@ -129,8 +129,8 @@ impl Gen6Reader {
     pub fn daycare2(&self) -> Daycare {
         Daycare {
             egg_seed: [
-                pnp::read(self.addrs.egg_seed_2),
                 pnp::read(self.addrs.egg_seed_2 + 0x4),
+                pnp::read(self.addrs.egg_seed_2),
             ],
             is_egg_ready: pnp::read::<u8>(self.addrs.egg_ready_2) != 0,
             parent1: self.egg_parent(self.addrs.is_parent1_occupied_2, self.addrs.parent1_2),


### PR DESCRIPTION
In the screenshot, the egg seed input is shown how PokeReader currently displays it. The egg seed column of the screenshot is the expected seed. Based on the -1 frame, the seed halves are backwards showing incorrect results.

![image](https://github.com/zaksabeast/PokeReader/assets/1857949/5df9ef01-8a33-4d53-b4ce-edf02ef4f991)
