### PR TITLE
Add DE, ES, and IT languages for Crystal

### DIFF
--- a/3gx/PokeReader.plgInfo
+++ b/3gx/PokeReader.plgInfo
@@ -16,7 +16,10 @@ Targets: # Low TitleId of games which are compatibles with this plugin (empty fo
     0x001B5100
     0x000C9C00
     0x00172800
+    0x00172B00
     0x00172E00
+    0x00173100
+    0x00173400
 
 Title: PokeReader
 

--- a/3gx/sources/main.c
+++ b/3gx/sources/main.c
@@ -22,7 +22,10 @@ typedef enum SupportedTitle
     GAME_UM = 0x00040000001B5100,
     GAME_TRANSPORTER = 0x00040000000C9C00,
     GAME_CRYSTAL_EN = 0x0004000000172800,
+    GAME_CRYSTAL_DE = 0x0004000000172B00,
     GAME_CRYSTAL_FR = 0x0004000000172E00,
+    GAME_CRYSTAL_ES = 0x0004000000173100,
+    GAME_CRYSTAL_IT = 0x0004000000173400,
 } SupportedTitle;
 
 static Handle thread;
@@ -230,7 +233,10 @@ void main(void)
         map_input_memory_block = 0x11f63c;
         break;
     case GAME_CRYSTAL_EN:
+    case GAME_CRYSTAL_DE:
     case GAME_CRYSTAL_FR:
+    case GAME_CRYSTAL_ES:
+    case GAME_CRYSTAL_IT:
         present_buffer_ptr = 0x14aa24;
         get_screen_jump_inst = 0xeb00b512;
         map_input_memory_block = 0x146a28;

--- a/reader_core/src/lib.rs
+++ b/reader_core/src/lib.rs
@@ -52,7 +52,11 @@ pub extern "C" fn initialize() {
         SupportedTitle::Or | SupportedTitle::As => gen6::init_oras(),
         SupportedTitle::X | SupportedTitle::Y => gen6::init_xy(),
         SupportedTitle::Transporter => transporter::init_transporter(),
-        SupportedTitle::Crytal | SupportedTitle::CrystalFr => crystal::init_crystal(),
+        SupportedTitle::CrystalEn
+        | SupportedTitle::CrystalDe
+        | SupportedTitle::CrystalFr
+        | SupportedTitle::CrystalEs
+        | SupportedTitle::CrystalIt => crystal::init_crystal(),
         SupportedTitle::Invalid => {}
     }
 }
@@ -65,7 +69,11 @@ pub extern "C" fn run_frame() {
         SupportedTitle::Or | SupportedTitle::As => gen6::run_oras_frame(),
         SupportedTitle::X | SupportedTitle::Y => gen6::run_xy_frame(),
         SupportedTitle::Transporter => transporter::run_frame(),
-        SupportedTitle::Crytal | SupportedTitle::CrystalFr => crystal::run_frame(),
+        SupportedTitle::CrystalEn
+        | SupportedTitle::CrystalDe
+        | SupportedTitle::CrystalFr
+        | SupportedTitle::CrystalEs
+        | SupportedTitle::CrystalIt => crystal::run_frame(),
         SupportedTitle::Invalid => {}
     }
 }

--- a/reader_core/src/title.rs
+++ b/reader_core/src/title.rs
@@ -15,8 +15,11 @@ pub enum SupportedTitle {
     Us = 0x00040000001B5000,
     Um = 0x00040000001B5100,
     Transporter = 0x00040000000C9C00,
-    Crytal = 0x0004000000172800,
+    CrystalEn = 0x0004000000172800,
+    CrystalDe = 0x0004000000172B00,
     CrystalFr = 0x0004000000172E00,
+    CrystalEs = 0x0004000000173100,
+    CrystalIt = 0x0004000000173400,
 }
 
 pub fn title_id() -> SupportedTitle {


### PR DESCRIPTION
Enables PokeReader to detect German, Spanish, and Italian versions of Crystal.

I was initially only going to add German version, but I found a list of title IDs from one of BlackShark's Gists:
<https://gist.github.com/Bl4ckSh4rk/256ed3b857c9677310837d5180121f35>

I think the Japanese version has different memory offsets, but I can not verify it myself.