### PR TITLE
(Crystal) Adds egg view

### DIFF
--- a/reader_core/src/crystal/frame.rs
+++ b/reader_core/src/crystal/frame.rs
@@ -20,6 +20,7 @@ enum CrystalView {
     Rng,
     Party,
     Wild,
+    Egg,
     Research,
     HelpMenu,
 }
@@ -37,6 +38,7 @@ const MENU: &'static [MenuOption<CrystalView>] = &[
     MenuOption::new(CrystalView::Rng, "RNG"),
     MenuOption::new(CrystalView::Party, "Party"),
     MenuOption::new(CrystalView::Wild, "Wild"),
+    MenuOption::new(CrystalView::Egg, "Egg"),
     MenuOption::new(CrystalView::Research, "Research"),
     MenuOption::new(CrystalView::HelpMenu, "Help"),
 ];
@@ -85,6 +87,7 @@ pub fn run_frame() {
             let slot = state.party_menu.update_and_draw(is_locked);
             draw_pkx(&reader.party((slot - 1) as u8));
         }
+        CrystalView::Egg => draw_pkx(&reader.egg()),
         CrystalView::Research => draw_research(&reader, state.frame),
         CrystalView::HelpMenu => state.help_menu.update_and_draw(is_locked),
         CrystalView::MainMenu => {

--- a/reader_core/src/crystal/reader.rs
+++ b/reader_core/src/crystal/reader.rs
@@ -59,6 +59,13 @@ impl Gen2Reader {
         Pk2::new(spec_index, atkdef, spespc, 0)
     }
 
+    pub fn egg(&self) -> Pk2 {
+        let spec_index = gb_mem::read_u8(0xDF7B);
+        let atkdef = gb_mem::read_u8(0xDF90);
+        let spespc = gb_mem::read_u8(0xDF91);
+        Pk2::new(spec_index, atkdef, spespc, 0)
+    }
+
     pub fn rng_state(&self) -> u16 {
         gb_mem::read_u16(self.addrs.gb_rng_ptr)
     }


### PR DESCRIPTION
(I realize this is an Unsolicited Feature, so I hope it's okay that I'm submitting this PR!)

The DVs of the next egg to be generated are calculated as soon as both Pokemon are deposited in the Day-Care in gen 2, so (if you can see them) you can reroll for desired DVs (for instance, a shiny) by just depositing and removing a Pokemon repeatedly, and then actually _generate_ the egg once you're going to get the one you want. Doing this is obviously significantly faster and easier than breeding "honest." So, I added a view to display that information in Crystal! This is a pretty simple addition, and I've tested it and confirmed it works, so hopefully everything is in order?